### PR TITLE
Add TypeScript dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,11 @@
     "mobx-devtools-mst": "^0.9.18",
     "prettier": "2.8.7",
     "react-scripts": "^5.0.1",
-    "web-vitals": "^3.1.1"
+    "web-vitals": "^3.1.1",
+    "typescript": "^5.0.4",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "@types/node": "^18.15.3"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
- add TypeScript and React type packages in devDependencies

## Testing
- `npm test` *(fails: craco not found)*
- `npm install --save-dev typescript @types/react @types/react-dom @types/node` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845178debb48332915d1969edd3d736